### PR TITLE
Added filesDeleted event during uploadDir

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,6 +455,7 @@ And these events:
    uploading.
  * `'fileUploadEnd' (localFilePath, s3Key)` - emitted when a file successfully
    finishes uploading.
+ * `'filesDeleted' ([s3Key])` - emitted when files are deleted from S3
 
 `uploadDir` works like this:
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -981,6 +981,7 @@ function syncDir(self, params, directionIsToS3) {
       if (fatalError) return;
       ee.deleteAmount += thisObjectsToDelete.length;
       ee.emit('progress');
+      ee.emit('filesDeleted', thisObjectsToDelete.map(function(file) { return file.Key; }));
       checkDoMoreWork();
     });
   }

--- a/test/test.js
+++ b/test/test.js
@@ -341,6 +341,7 @@ describe("s3", function () {
   });
 
   it("uploadDir with deleteRemoved", function(done) {
+    var filesDeleted = false;
     var client = createClient();
     var params = {
       localDir: path.join(__dirname, "dir2"),
@@ -351,7 +352,11 @@ describe("s3", function () {
       },
     };
     var uploader = client.uploadDir(params);
+    uploader.on('filesDeleted', function(items) {
+      filesDeleted = true;
+    });
     uploader.on('end', function() {
+      assert(filesDeleted, "expected filesDeleted event to be triggered");
       done();
     });
   });


### PR DESCRIPTION
Added event emitting for `filesDeleted` during `uploadDir`, which emits a list of s3Keys that were deleted.  Use case is to log files that were removed.